### PR TITLE
docs: fixed 2.x readme links error && typo

### DIFF
--- a/2.x/README.md
+++ b/2.x/README.md
@@ -56,7 +56,7 @@ WePY (发音: /'wepi/) 项目启动于 2017 年 11 月份， 是小程序最早�
 <config>
 {
   usingComponents: {
-    mycomm: "~@/components/some-component"
+    mycom: "~@/components/some-component"
   }
 }
 </config>
@@ -164,6 +164,6 @@ GitHub掘金版、
 
 [Changelog](https://tencent.github.io/wepy/document.html#/changelog)
 
-[Contributing](./CONTRIBUTING.md)
+[Contributing](https://github.com/Tencent/wepy/blob/2.0.x/CONTRIBUTING.md)
 
-[License MIT](./LICENSE)
+[License MIT](https://github.com/Tencent/wepy/blob/2.0.x/LICENSE)


### PR DESCRIPTION
1. 单词拼写错误 
mycomm => mycom
2. links跳转无效