### PR TITLE
Modify the plugin-uglify name

### DIFF
--- a/2.x/plugin/official.md
+++ b/2.x/plugin/official.md
@@ -236,12 +236,12 @@ var url = http://www.foo.com
 ### 使用
 
 ```
-const UglifyPlugin = require('@wepy/plugin-uglify');
+const PluginUglifyjs = require('@wepy/plugin-uglifyjs');
 
 module.exports = {
   ...
   plugins: [
-    UglifyPlugin({
+    PluginUglifyjs({
       // options
     })
   ]

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1252,7 +1252,7 @@ li.social-link a {
 .feature-item {
   display: block;
   text-decoration: none;
-  width: 33.3%;
+  width: 30%;
   background-color: white;
   border-radius: 8px;
   position: relative;


### PR DESCRIPTION
Modification of document content(#11 )
The name of the plugin-uglify in the description page of plugin uglify is modified to solve the problem that the relevant package cannot be found when running npm install.